### PR TITLE
Remove data leakage in HTML comment

### DIFF
--- a/resources/views/committee/committee.blade.php
+++ b/resources/views/committee/committee.blade.php
@@ -2,7 +2,6 @@
 @section('content')
 
 <div class="overlap">
-    <!-- {{$committee}} -->
     <div class="row">
         <div class="col-12 col-md-6 px-1 px-md-5">
             <h1 class="center">{{$committee->DisplayName}}</h1>


### PR DESCRIPTION
Models should be restricted in what info they give out publicly by default, but this definitely did not help in preventing a leakage of personal data.